### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,15 @@ add_executable(lxqt-policykit-agent
     ${QM_LOADER}
 )
 
+target_compile_definitions(lxqt-policykit-agent
+    PRIVATE
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
+)
+
 target_link_libraries(lxqt-policykit-agent
     Qt5::Widgets
     lxqt

--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -45,7 +45,7 @@ PolicykitAgent::PolicykitAgent(QObject *parent)
       m_gui(0)
 {
     PolkitQt1::UnixSessionSubject session(getpid());
-    registerListener(session, "/org/lxqt/PolicyKit1/AuthenticationAgent");
+    registerListener(session, QStringLiteral("/org/lxqt/PolicyKit1/AuthenticationAgent"));
 }
 
 PolicykitAgent::~PolicykitAgent()


### PR DESCRIPTION
* Disables automatic conversions from 8-bit strings (char *) to unicode
  QStrings.
* Disables automatic conversion from QString to 8-bit strings (char *).
* Disables automatic conversions from QByteArray to const char * or const
  void *.
* Disables automatic conversions from QString (or char *) to QUrl.
* Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.