### PR TITLE
Delete Password from Qlineedit, prevent to show pass in cleartext

### DIFF
--- a/src/policykitagentgui.cpp
+++ b/src/policykitagentgui.cpp
@@ -88,9 +88,10 @@ QString PolicykitAgentGUI::identity()
     return identityComboBox->currentText();
 }
 
-QString PolicykitAgentGUI::response()
-{
-    return passwordEdit->text();
+QString PolicykitAgentGUI::response() {
+  QString response = passwordEdit->text();
+  passwordEdit->setText(QString());
+  return response;
 }
 
 void PolicykitAgentGUI::onIdentityChanged(int index)


### PR DESCRIPTION
When using U2F pam-based authentication, pam asks for inserting the U2F-Key after the password was typed in. This message is displayed in the same Dialog as the previous password request. The dialog still knows the password and then displays the QlineEdit.text() in cleartext. This patch avoids that.