### PR TITLE
make the infobox non-modal: for u2f tokens this saves a click

### DIFF
--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -42,7 +42,8 @@ namespace LXQtPolicykit
 PolicykitAgent::PolicykitAgent(QObject *parent)
     : PolkitQt1::Agent::Listener(parent),
       m_inProgress(false),
-      m_gui(0)
+      m_gui(0),
+      m_infobox(nullptr)
 {
     PolkitQt1::UnixSessionSubject session(getpid());
     registerListener(session, QStringLiteral("/org/lxqt/PolicyKit1/AuthenticationAgent"));
@@ -54,6 +55,9 @@ PolicykitAgent::~PolicykitAgent()
     {
         m_gui->blockSignals(true);
         m_gui->deleteLater();
+    }
+    if(m_infobox) {
+      delete m_infobox;
     }
 }
 
@@ -146,7 +150,10 @@ void PolicykitAgent::completed(bool gainedAuthorization)
         session->result()->setCompleted();
         m_inProgress = false;
     }
-
+    if (m_infobox){
+      m_infobox->hide();
+      delete m_infobox;
+    }
     delete session;
 }
 
@@ -157,7 +164,13 @@ void PolicykitAgent::showError(const QString &text)
 
 void PolicykitAgent::showInfo(const QString &text)
 {
-    QMessageBox::information(0, tr("PolicyKit Information"), text);
+    m_infobox = new QMessageBox(0);
+    m_infobox->setText(text);
+    m_infobox->setWindowTitle(tr("PolicyKit Information"));
+    m_infobox->setStandardButtons(QMessageBox::Ok);
+    m_infobox->setAttribute(Qt::WA_DeleteOnClose);
+    m_infobox->setModal(false);
+    m_infobox->show();
 }
 
 } //namespace

--- a/src/policykitagent.h
+++ b/src/policykitagent.h
@@ -37,6 +37,7 @@
 
 #include <QApplication>
 #include <QHash>
+#include <QMessageBox>
 
 namespace LXQtPolicykit
 {
@@ -70,6 +71,7 @@ public slots:
 private:
     bool m_inProgress;
     PolicykitAgentGUI * m_gui;
+    QMessageBox *m_infobox;
     QHash<PolkitQt1::Agent::Session*,PolkitQt1::Identity> m_SessionIdentity;
 };
 


### PR DESCRIPTION
When using U2F pam-based authentication, pam asks for inserting the U2F-Key after the password was typed in. In my case i need to press a button. This infomation is displayed in a modal QMessagebox. I need to click it (and the button on the U2F device) before the authentication proceeds.

This is annoying, because i need to click and push.

This patch makes the QMessageBox a non-modal window which goes away, when the authentication is completed.