### PR TITLE
PolicykitAgent: Add better memory handling

### DIFF
--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -59,6 +59,14 @@ PolicykitAgent::~PolicykitAgent()
     if(m_infobox) {
       delete m_infobox;
     }
+    deleteSessions();
+}
+
+void PolicykitAgent::deleteSessions()
+{
+    for (auto i = m_SessionIdentity.begin(), i_e = m_SessionIdentity.end(); i != i_e; ++i)
+        delete i.key();
+    m_SessionIdentity.clear();
 }
 
 
@@ -76,7 +84,7 @@ void PolicykitAgent::initiateAuthentication(const QString &actionId,
         return;
     }
     m_inProgress = true;
-    m_SessionIdentity.clear();
+    deleteSessions();
 
     if (m_gui)
     {
@@ -138,7 +146,7 @@ void PolicykitAgent::completed(bool gainedAuthorization)
     Q_ASSERT(session);
     Q_ASSERT(m_gui);
 
-    if (m_gui->identity() == m_SessionIdentity[session].toString())
+    if (m_inProgress && m_gui->identity() == m_SessionIdentity[session].toString())
     {
         if (!gainedAuthorization)
         {
@@ -154,7 +162,6 @@ void PolicykitAgent::completed(bool gainedAuthorization)
       m_infobox->hide();
       delete m_infobox;
     }
-    delete session;
 }
 
 void PolicykitAgent::showError(const QString &text)

--- a/src/policykitagent.h
+++ b/src/policykitagent.h
@@ -68,6 +68,9 @@ public slots:
     void showError(const QString &text);
     void showInfo(const QString &text);
 
+protected:
+    void deleteSessions();
+
 private:
     bool m_inProgress;
     PolicykitAgentGUI * m_gui;


### PR DESCRIPTION
Don't delete the session in the slot as we can't be sure if any other
activity is done on the sender object after our slot finishes.