### PR TITLE
Prevent multiple "authentication already in progress" dialogs

### DIFF
--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -42,6 +42,7 @@ namespace LXQtPolicykit
 PolicykitAgent::PolicykitAgent(QObject *parent)
     : PolkitQt1::Agent::Listener(parent),
       m_inProgress(false),
+      m_inProgressAlert(false),
       m_gui(nullptr),
       m_infobox(nullptr)
 {
@@ -78,7 +79,11 @@ void PolicykitAgent::initiateAuthentication(const QString &actionId,
 {
     if (m_inProgress)
     {
-        QMessageBox::information(nullptr, tr("PolicyKit Information"), tr("Another authentication is in progress. Please try again later."));
+        if (!m_inProgressAlert) {
+            m_inProgressAlert = true;
+            QMessageBox::information(nullptr, tr("PolicyKit Information"), tr("Another authentication is in progress. Please try again later."));
+            m_inProgressAlert = false;
+        }
         return;
     }
     m_inProgress = true;

--- a/src/policykitagent.h
+++ b/src/policykitagent.h
@@ -73,6 +73,7 @@ protected:
 
 private:
     bool m_inProgress;
+    bool m_inProgressAlert;
     PolicykitAgentGUI * m_gui;
     QMessageBox *m_infobox;
     QHash<PolkitQt1::Agent::Session*,PolkitQt1::Identity> m_SessionIdentity;


### PR DESCRIPTION
Hello,

Currently, if a polkit authorization request comes in while another one is in progress, an alert dialog is shown to the user saying to please try again later.  This is helpful and points out badly-behaved software.  Case in point: Steam has a long-standing bug where it attempts to access NetworkManager's system connections every 10 or so seconds, because reasons:

https://github.com/ValveSoftware/steam-for-linux/issues/7856

When authentication is required to modify system connections, this interacts poorly with LXQt: an additional dialog interrupts the user every 10 seconds, on top of any existing ones.  Ideally I would like to be able to just ignore the initial prompt or two, minimize them, and get on with playing games.  This works under Plasma, which appears to silently ignore any polkit requests while an auth dialog is already open.

Of course this is a bug with Steam, but I also think this can be considered a slight DoS of lxqt-policykit.  Would you consider putting a limit in place like this PR does, to prevent an endless stream of dialogs?

Thanks.