### PR TITLE
PolicykitAgent: Set completed of new authentication

### DIFF
--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -79,11 +79,15 @@ void PolicykitAgent::initiateAuthentication(const QString &actionId,
 {
     if (m_inProgress)
     {
+	const QString & info = tr("Another authentication is in progress. Please try again later.");
         if (!m_inProgressAlert) {
             m_inProgressAlert = true;
-            QMessageBox::information(nullptr, tr("PolicyKit Information"), tr("Another authentication is in progress. Please try again later."));
+	    QMessageBox::information(nullptr, tr("PolicyKit Information"), info);
+
             m_inProgressAlert = false;
         }
+        result->setError(info);
+        result->setCompleted();
         return;
     }
     m_inProgress = true;


### PR DESCRIPTION
..when other one in progress already

Notify the polkit, that we can't do next authentication if one is already in progress. This prevents the initial caller to possibly wait indefinetly for the authentication.