### PR TITLE
Fix SIGSEGV caused by use-after-free of m_infobox in PolicykitAgent

### DIFF
--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -57,7 +57,10 @@ PolicykitAgent::~PolicykitAgent()
         m_gui->blockSignals(true);
         m_gui->deleteLater();
     }
-    delete m_infobox;
+    if (m_infobox != nullptr) {
+        m_infobox->deleteLater();
+        m_infobox = nullptr;
+    }
     deleteSessions();
 }
 
@@ -167,7 +170,8 @@ void PolicykitAgent::completed(bool gainedAuthorization)
     }
     if (m_infobox != nullptr){
       m_infobox->hide();
-      delete m_infobox;
+      m_infobox->deleteLater();
+      m_infobox = nullptr;
     }
 }
 
@@ -178,11 +182,13 @@ void PolicykitAgent::showError(const QString &text)
 
 void PolicykitAgent::showInfo(const QString &text)
 {
+    if (m_infobox != nullptr) {
+        m_infobox->deleteLater();
+    }
     m_infobox = new QMessageBox(nullptr);
     m_infobox->setText(text);
     m_infobox->setWindowTitle(tr("PolicyKit Information"));
     m_infobox->setStandardButtons(QMessageBox::Ok);
-    m_infobox->setAttribute(Qt::WA_DeleteOnClose);
     m_infobox->setModal(false);
     m_infobox->show();
 }


### PR DESCRIPTION
## Pull Request Description

### Summary
- Fix `SIGSEGV` caused by use-after-free of `m_infobox` in `PolicykitAgent`
- Replaced direct `delete m_infobox` calls with `m_infobox->deleteLater()`
- Added null checks before accessing or deleting `m_infobox`
- Reset `m_infobox` to `nullptr` after scheduling deletion
- Ensured previous info dialog is destroyed before creating a new one in `showInfo()`

### Why
The previous implementation could access or delete a `QMessageBox` object after it was already freed, causing a crash in `PolicykitAgent`.

### Result
Improves stability by preventing invalid access to `m_infobox` and making dialog lifecycle handling safer.

### Link bug 
https://bugzilla.redhat.com/show_bug.cgi?id=2480386
