### PR TITLE
Fix PolicyKit auth dialogs: no duplicate failures, smarter info handling

### DIFF
--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -43,8 +43,10 @@ PolicykitAgent::PolicykitAgent(QObject *parent)
     : PolkitQt1::Agent::Listener(parent),
       m_inProgress(false),
       m_inProgressAlert(false),
-      m_gui(nullptr),
-      m_infobox(nullptr)
+      m_userCancelled(false),
+      m_errorShown(false),
+      m_infoShown(false),
+      m_gui(nullptr)
 {
     PolkitQt1::UnixSessionSubject session(getpid());
     registerListener(session, QStringLiteral("/org/lxqt/PolicyKit1/AuthenticationAgent"));
@@ -57,7 +59,6 @@ PolicykitAgent::~PolicykitAgent()
         m_gui->blockSignals(true);
         m_gui->deleteLater();
     }
-    delete m_infobox;
     deleteSessions();
 }
 
@@ -91,6 +92,10 @@ void PolicykitAgent::initiateAuthentication(const QString &actionId,
         return;
     }
     m_inProgress = true;
+    m_userCancelled = false;
+    m_errorShown = false;
+    m_infoShown = false;
+    m_lastError.clear();
     deleteSessions();
 
     if (m_gui != nullptr)
@@ -133,14 +138,22 @@ void PolicykitAgent::request(const QString &request, bool echo)
     Q_ASSERT(session);
     Q_ASSERT(m_gui);
 
+    // PAM may still ask for a password after showInfo (e.g. account locked); don't.
+    if (m_infoShown) {
+        session->cancel();
+        return;
+    }
+
     PolkitQt1::Identity identity = m_SessionIdentity[session];
     m_gui->setPrompt(identity, request, echo);
     connect(m_gui, &QDialog::finished, this, [this, session] (int result)
     {
         if (result == QDialog::Accepted && m_gui->identity() == m_SessionIdentity[session].toString())
             session->setResponse(m_gui->response());
-        else
+        else {
+            m_userCancelled = true;
             session->cancel();
+        }
     });
     m_gui->show();
     m_gui->activateWindow();
@@ -155,9 +168,12 @@ void PolicykitAgent::completed(bool gainedAuthorization)
 
     if (m_inProgress && m_gui->identity() == m_SessionIdentity[session].toString())
     {
-        if (!gainedAuthorization)
+        if (!gainedAuthorization && !m_userCancelled && !m_errorShown)
         {
-            QMessageBox::information(nullptr, tr("Authorization Failed"), tr("Authorization failed for some reason"));
+            const QString text = m_lastError.isEmpty()
+                ? tr("Authentication failed")
+                : m_lastError;
+            QMessageBox::information(nullptr, tr("Authorization Failed"), text);
         }
 
         // Note: the setCompleted() must be called exacly once (as the
@@ -165,26 +181,22 @@ void PolicykitAgent::completed(bool gainedAuthorization)
         session->result()->setCompleted();
         m_inProgress = false;
     }
-    if (m_infobox != nullptr){
-      m_infobox->hide();
-      delete m_infobox;
-    }
 }
 
 void PolicykitAgent::showError(const QString &text)
 {
+    m_lastError = text;
+    m_errorShown = true;
     QMessageBox::warning(nullptr, tr("PolicyKit Error"), text);
 }
 
 void PolicykitAgent::showInfo(const QString &text)
 {
-    m_infobox = new QMessageBox(nullptr);
-    m_infobox->setText(text);
-    m_infobox->setWindowTitle(tr("PolicyKit Information"));
-    m_infobox->setStandardButtons(QMessageBox::Ok);
-    m_infobox->setAttribute(Qt::WA_DeleteOnClose);
-    m_infobox->setModal(false);
-    m_infobox->show();
+    m_lastError = text;
+    m_errorShown = true;
+    m_infoShown = true;
+    // Blocking so callers only see their error after the user dismisses this.
+    QMessageBox::information(nullptr, tr("PolicyKit Information"), text);
 }
 
 } //namespace

--- a/src/policykitagent.h
+++ b/src/policykitagent.h
@@ -37,7 +37,6 @@
 
 #include <QApplication>
 #include <QHash>
-#include <QMessageBox>
 
 namespace LXQtPolicykit
 {
@@ -74,8 +73,11 @@ protected:
 private:
     bool m_inProgress;
     bool m_inProgressAlert;
+    bool m_userCancelled;
+    bool m_errorShown;
+    bool m_infoShown;
+    QString m_lastError;
     PolicykitAgentGUI * m_gui;
-    QMessageBox *m_infobox;
     QHash<PolkitQt1::Agent::Session*,PolkitQt1::Identity> m_SessionIdentity;
 };
 


### PR DESCRIPTION
I was digging into the code and found some bugs, this PR addresses them:

- No more redundant “Authorization Failed” popups** when the user cancelled, or when an error/info dialog was already shown.

- 🧠 **Remembers the last PAM/Polkit message** (`m_lastError`) and reuses it instead of the vague *“Authorization failed for some reason”*

🔒 **After `showInfo` (e.g. account locked)**, a follow-up password `request` is cancelled instead of opening another prompt

🪟 **`showInfo` is now a blocking dialog** so the user actually reads the info before anything else piles

Basically, before this changes, let's say you tried to mount a drive, then the authorization dialog will show, if you clicked on cancel, then another dialog would appear
<img width="1539" height="700" alt="image" src="https://github.com/user-attachments/assets/f32dffd1-8749-476c-9df9-c8cd9377b833" />
<img width="736" height="221" alt="image" src="https://github.com/user-attachments/assets/47bca083-466c-4288-bc15-d4e3d2c2e0d5" />

Instead of that, if you clicked on cancel, then no more dialogs would appear, because the user cancelled the operation, the only dialog that appears in the end is `libfm-qt/pcmanfm-qt` dialog:
<img width="699" height="284" alt="image" src="https://github.com/user-attachments/assets/0023365a-aa50-4e5f-a25a-caddf9a24dd1" />
(which is debatable, should we show any more extra dialogs? if the user cancelled the operation I think no more dialogs should appear, only in case of actual errors, but that would be another conversation for `libfm-qt/pcmanfm-qt`)

Also, the dialog that says "Authorization failed for some reason" (the one coming from `lxqt-policykit` and the one that says "Not authorized to perform operation (the one coming from `libfm-qt/pcmanfm-qt`) appeared at the same time, now, the latter one only appears after closing the first one, so there won't be multiple dialog at the same time.

When auth does not succeed, completed no longer always pops “for some reason”. It does this:

User cancelled (`m_userCancelled`) → no agent failure box.
Already showed a message (`m_errorShown` from `showError` or `showInfo`) → no second box (PAM/faillock text was already shown).
Otherwise (typical wrong password on your machine: no `showError`) → one box titled “Authorization Failed” with body “Authentication failed”, or `m_lastError` if somehow set without having shown it yet.

Related behavior elsewhere:
`showInfo` (e.g. account locked) → blocking info dialog, then skip any following password prompt.
`showError` → warning with PAM’s text, then skip the generic/completed box.

Closes https://github.com/lxqt/lxqt-policykit/issues/167